### PR TITLE
Add Mise MCP Server and GitHub workflow files

### DIFF
--- a/.github/workflows/ast-grep-mcp-artifact.yaml
+++ b/.github/workflows/ast-grep-mcp-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push ast-grep-mcp OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "ast-grep-mcp/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "ast-grep-mcp/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: ast-grep-mcp
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls ast-grep-mcp/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > ast-grep-mcp/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x ast-grep-mcp/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > ast-grep-mcp/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/ast-grep-mcp:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput ast-grep-mcp/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/ast-grep-mcp@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/chromaDB-artifact.yaml
+++ b/.github/workflows/chromaDB-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push chromaDB OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "chromaDB/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "chromaDB/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: chromaDB
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls chromaDB/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > chromaDB/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x chromaDB/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > chromaDB/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/chromaDB:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput chromaDB/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/chromaDB@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/cosign-mcp-artifact.yaml
+++ b/.github/workflows/cosign-mcp-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push cosign-mcp OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "cosign-mcp/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "cosign-mcp/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: cosign-mcp
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls cosign-mcp/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > cosign-mcp/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x cosign-mcp/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > cosign-mcp/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/cosign-mcp:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput cosign-mcp/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/cosign-mcp@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/ctags-mcp-artifact.yaml
+++ b/.github/workflows/ctags-mcp-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push ctags-mcp OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "ctags-mcp/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "ctags-mcp/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: ctags-mcp
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls ctags-mcp/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > ctags-mcp/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x ctags-mcp/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > ctags-mcp/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/ctags-mcp:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput ctags-mcp/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/ctags-mcp@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/dependency-check-artifact.yaml
+++ b/.github/workflows/dependency-check-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push dependency-check OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "dependency-check/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "dependency-check/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: dependency-check
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls dependency-check/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > dependency-check/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x dependency-check/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > dependency-check/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/dependency-check:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput dependency-check/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/dependency-check@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/git-mcp-artifact.yaml
+++ b/.github/workflows/git-mcp-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push git-mcp OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "git-mcp/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "git-mcp/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: git-mcp
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls git-mcp/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > git-mcp/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x git-mcp/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > git-mcp/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/git-mcp:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput git-mcp/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/git-mcp@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/gitingest-mcp-artifact.yaml
+++ b/.github/workflows/gitingest-mcp-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push gitingest-mcp OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "gitingest-mcp/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "gitingest-mcp/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: gitingest-mcp
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls gitingest-mcp/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > gitingest-mcp/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x gitingest-mcp/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > gitingest-mcp/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/gitingest-mcp:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput gitingest-mcp/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/gitingest-mcp@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/grype-mcp-server-artifact.yaml
+++ b/.github/workflows/grype-mcp-server-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push grype-mcp-server OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "grype-mcp-server/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "grype-mcp-server/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: grype-mcp-server
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls grype-mcp-server/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > grype-mcp-server/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x grype-mcp-server/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > grype-mcp-server/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/grype-mcp-server:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput grype-mcp-server/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/grype-mcp-server@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/hurl-mcp-server-artifact.yaml
+++ b/.github/workflows/hurl-mcp-server-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push hurl-mcp-server OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "hurl-mcp-server/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "hurl-mcp-server/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: hurl-mcp-server
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls hurl-mcp-server/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > hurl-mcp-server/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x hurl-mcp-server/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > hurl-mcp-server/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/hurl-mcp-server:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput hurl-mcp-server/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/hurl-mcp-server@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/inspektor-gadget-mcp-artifact.yaml
+++ b/.github/workflows/inspektor-gadget-mcp-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push inspektor-gadget-mcp OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "inspektor-gadget-mcp/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "inspektor-gadget-mcp/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: inspektor-gadget-mcp
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls inspektor-gadget-mcp/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > inspektor-gadget-mcp/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x inspektor-gadget-mcp/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > inspektor-gadget-mcp/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/inspektor-gadget-mcp:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput inspektor-gadget-mcp/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/inspektor-gadget-mcp@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/llm-sandbox-mcp-artifact.yaml
+++ b/.github/workflows/llm-sandbox-mcp-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push llm-sandbox-mcp OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "llm-sandbox-mcp/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "llm-sandbox-mcp/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: llm-sandbox-mcp
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls llm-sandbox-mcp/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > llm-sandbox-mcp/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x llm-sandbox-mcp/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > llm-sandbox-mcp/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/llm-sandbox-mcp:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput llm-sandbox-mcp/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/llm-sandbox-mcp@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/locagent-mcp-artifact.yaml
+++ b/.github/workflows/locagent-mcp-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push locagent-mcp OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "locagent-mcp/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "locagent-mcp/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: locagent-mcp
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls locagent-mcp/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > locagent-mcp/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x locagent-mcp/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > locagent-mcp/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/locagent-mcp:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput locagent-mcp/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/locagent-mcp@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/makefile-mcp-artifact.yaml
+++ b/.github/workflows/makefile-mcp-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push makefile-mcp OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "makefile-mcp/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "makefile-mcp/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: makefile-mcp
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls makefile-mcp/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > makefile-mcp/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x makefile-mcp/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > makefile-mcp/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/makefile-mcp:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput makefile-mcp/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/makefile-mcp@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/markItDown-mcp-artifact.yaml
+++ b/.github/workflows/markItDown-mcp-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push markItDown-mcp OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "markItDown-mcp/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "markItDown-mcp/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: markItDown-mcp
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls markItDown-mcp/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > markItDown-mcp/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x markItDown-mcp/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > markItDown-mcp/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/markItDown-mcp:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput markItDown-mcp/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/markItDown-mcp@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/markdownlint-mcp-server-artifact.yaml
+++ b/.github/workflows/markdownlint-mcp-server-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push markdownlint-mcp-server OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "markdownlint-mcp-server/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "markdownlint-mcp-server/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: markdownlint-mcp-server
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls markdownlint-mcp-server/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > markdownlint-mcp-server/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x markdownlint-mcp-server/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > markdownlint-mcp-server/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/markdownlint-mcp-server:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput markdownlint-mcp-server/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/markdownlint-mcp-server@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/meilisearch-mcp-artifact.yaml
+++ b/.github/workflows/meilisearch-mcp-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push meilisearch-mcp OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "meilisearch-mcp/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "meilisearch-mcp/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: meilisearch-mcp
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls meilisearch-mcp/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > meilisearch-mcp/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x meilisearch-mcp/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > meilisearch-mcp/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/meilisearch-mcp:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput meilisearch-mcp/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/meilisearch-mcp@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/mindsdb-mcp-artifact.yaml
+++ b/.github/workflows/mindsdb-mcp-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push mindsdb-mcp OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "mindsdb-mcp/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "mindsdb-mcp/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: mindsdb-mcp
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls mindsdb-mcp/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > mindsdb-mcp/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x mindsdb-mcp/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > mindsdb-mcp/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/mindsdb-mcp:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput mindsdb-mcp/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/mindsdb-mcp@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/mise-tasks-mcp-artifact.yaml
+++ b/.github/workflows/mise-tasks-mcp-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push mise-tasks-mcp OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "mise-tasks-mcp/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "mise-tasks-mcp/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: mise-tasks-mcp
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls mise-tasks-mcp/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > mise-tasks-mcp/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x mise-tasks-mcp/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > mise-tasks-mcp/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/mise-tasks-mcp:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput mise-tasks-mcp/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/mise-tasks-mcp@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/multilspy-mcp-artifact.yaml
+++ b/.github/workflows/multilspy-mcp-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push multilspy-mcp OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "multilspy-mcp/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "multilspy-mcp/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: multilspy-mcp
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls multilspy-mcp/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > multilspy-mcp/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x multilspy-mcp/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > multilspy-mcp/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/multilspy-mcp:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput multilspy-mcp/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/multilspy-mcp@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/neo4j-cypher-mcp-artifact.yaml
+++ b/.github/workflows/neo4j-cypher-mcp-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push neo4j-cypher-mcp OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "neo4j-cypher-mcp/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "neo4j-cypher-mcp/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: neo4j-cypher-mcp
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls neo4j-cypher-mcp/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > neo4j-cypher-mcp/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x neo4j-cypher-mcp/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > neo4j-cypher-mcp/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/neo4j-cypher-mcp:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput neo4j-cypher-mcp/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/neo4j-cypher-mcp@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/neo4j-memory-mcp-artifact.yaml
+++ b/.github/workflows/neo4j-memory-mcp-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push neo4j-memory-mcp OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "neo4j-memory-mcp/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "neo4j-memory-mcp/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: neo4j-memory-mcp
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls neo4j-memory-mcp/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > neo4j-memory-mcp/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x neo4j-memory-mcp/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > neo4j-memory-mcp/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/neo4j-memory-mcp:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput neo4j-memory-mcp/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/neo4j-memory-mcp@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/opengrep-mcp-artifact.yaml
+++ b/.github/workflows/opengrep-mcp-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push opengrep-mcp OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "opengrep-mcp/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "opengrep-mcp/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: opengrep-mcp
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls opengrep-mcp/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > opengrep-mcp/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x opengrep-mcp/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > opengrep-mcp/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/opengrep-mcp:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput opengrep-mcp/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/opengrep-mcp@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/qdrant-mcp-artifact.yaml
+++ b/.github/workflows/qdrant-mcp-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push qdrant-mcp OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "qdrant-mcp/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "qdrant-mcp/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: qdrant-mcp
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls qdrant-mcp/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > qdrant-mcp/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x qdrant-mcp/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > qdrant-mcp/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/qdrant-mcp:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput qdrant-mcp/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/qdrant-mcp@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/renovate-mcp-server-artifact.yaml
+++ b/.github/workflows/renovate-mcp-server-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push renovate-mcp-server OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "renovate-mcp-server/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "renovate-mcp-server/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: renovate-mcp-server
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls renovate-mcp-server/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > renovate-mcp-server/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x renovate-mcp-server/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > renovate-mcp-server/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/renovate-mcp-server:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput renovate-mcp-server/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/renovate-mcp-server@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/semgrep-mcp-artifact.yaml
+++ b/.github/workflows/semgrep-mcp-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push semgrep-mcp OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "semgrep-mcp/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "semgrep-mcp/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: semgrep-mcp
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls semgrep-mcp/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > semgrep-mcp/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x semgrep-mcp/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > semgrep-mcp/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/semgrep-mcp:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput semgrep-mcp/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/semgrep-mcp@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/serena-mcp-artifact.yaml
+++ b/.github/workflows/serena-mcp-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push serena-mcp OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "serena-mcp/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "serena-mcp/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: serena-mcp
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls serena-mcp/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > serena-mcp/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x serena-mcp/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > serena-mcp/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/serena-mcp:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput serena-mcp/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/serena-mcp@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/strace-mcp-artifact.yaml
+++ b/.github/workflows/strace-mcp-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push strace-mcp OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "strace-mcp/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "strace-mcp/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: strace-mcp
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls strace-mcp/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > strace-mcp/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x strace-mcp/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > strace-mcp/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/strace-mcp:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput strace-mcp/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/strace-mcp@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/syft-mcp-server-artifact.yaml
+++ b/.github/workflows/syft-mcp-server-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push syft-mcp-server OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "syft-mcp-server/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "syft-mcp-server/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: syft-mcp-server
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls syft-mcp-server/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > syft-mcp-server/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x syft-mcp-server/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > syft-mcp-server/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/syft-mcp-server:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput syft-mcp-server/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/syft-mcp-server@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/taskfile-mcp-artifact.yaml
+++ b/.github/workflows/taskfile-mcp-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push taskfile-mcp OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "taskfile-mcp/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "taskfile-mcp/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: taskfile-mcp
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls taskfile-mcp/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > taskfile-mcp/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x taskfile-mcp/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > taskfile-mcp/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/taskfile-mcp:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput taskfile-mcp/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/taskfile-mcp@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/tree-mcp-server-artifact.yaml
+++ b/.github/workflows/tree-mcp-server-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push tree-mcp-server OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "tree-mcp-server/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "tree-mcp-server/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: tree-mcp-server
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls tree-mcp-server/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > tree-mcp-server/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x tree-mcp-server/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > tree-mcp-server/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/tree-mcp-server:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput tree-mcp-server/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/tree-mcp-server@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/tree-sitter-graph-mcp-artifact.yaml
+++ b/.github/workflows/tree-sitter-graph-mcp-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push tree-sitter-graph-mcp OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "tree-sitter-graph-mcp/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "tree-sitter-graph-mcp/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: tree-sitter-graph-mcp
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls tree-sitter-graph-mcp/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > tree-sitter-graph-mcp/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x tree-sitter-graph-mcp/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > tree-sitter-graph-mcp/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/tree-sitter-graph-mcp:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput tree-sitter-graph-mcp/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/tree-sitter-graph-mcp@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/tree-sitter-mcp-artifact.yaml
+++ b/.github/workflows/tree-sitter-mcp-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push tree-sitter-mcp OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "tree-sitter-mcp/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "tree-sitter-mcp/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: tree-sitter-mcp
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls tree-sitter-mcp/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > tree-sitter-mcp/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x tree-sitter-mcp/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > tree-sitter-mcp/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/tree-sitter-mcp:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput tree-sitter-mcp/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/tree-sitter-mcp@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/.github/workflows/trivy-mcp-server-artifact.yaml
+++ b/.github/workflows/trivy-mcp-server-artifact.yaml
@@ -1,0 +1,109 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Build & Push trivy-mcp-server OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "trivy-mcp-server/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "trivy-mcp-server/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+        working-directory: trivy-mcp-server
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls trivy-mcp-server/dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > trivy-mcp-server/dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x trivy-mcp-server/dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > trivy-mcp-server/dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/trivy-mcp-server:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput trivy-mcp-server/dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}/trivy-mcp-server@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/hack/artifact-build-and-push.yaml
+++ b/hack/artifact-build-and-push.yaml
@@ -1,0 +1,101 @@
+# Simplified Python Package OCI Build
+# Works with ANY Python package that can be run with: python -m package_name
+
+name: Simple Python OCI Build
+
+on:
+  push:
+    tags: ["v*"]
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write  # Required for OIDC authentication with cosign
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist/
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+
+      - name: Install Genval
+        run: |
+          go install github.com/intelops/genval@pre-main
+
+      - name: Create simple runner
+        run: |
+          # Extract package name from wheel
+          WHEEL=$(ls dist/*.whl | head -1)
+          PACKAGE_NAME=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Create a simple run script
+          cat > dist/run.sh << 'EOF'
+          #!/bin/bash
+          # Simple Python package runner
+          WHEEL=$(ls "$(dirname "$0")"/*.whl | head -1)
+          PKG=$(basename "$WHEEL" | cut -d'-' -f1 | tr '-' '_')
+
+          # Install and run
+          pip install "$WHEEL" --quiet
+          python -m "$PKG" "$@"
+          EOF
+          chmod +x dist/run.sh
+
+          # Create metadata
+          echo "{\"package\": \"$PACKAGE_NAME\", \"wheel\": \"$(basename $WHEEL)\"}" > dist/metadata.json
+
+      - name: Push OCI artifact
+        id: push
+        run: |
+          # Push OCI artifact using genval (expects directory, not tar)
+          TAG="${GITHUB_REF_NAME:-latest}"
+          IMAGE_URI="${{ env.REGISTRY }}/${{ env.REPOSITORY }}:$TAG"
+
+          # genval expects oci:// prefix for push
+          OUTPUT=$(genval artifact push --reqinput dist \
+          --dest "oci://$IMAGE_URI" \
+          --annotations="author=capten.ai" 2>&1)
+
+          echo "$OUTPUT"
+          
+          # Extract digest from genval output
+          DIGEST=$(echo "$OUTPUT" | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+          
+          echo "✅ Pushed to: $IMAGE_URI"
+          echo "IMAGE_URI=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "IMAGE_DIGEST=${{ env.REGISTRY }}/${{ env.REPOSITORY }}@$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Artifact with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          echo "Signing artifact ${{ steps.push.outputs.IMAGE_DIGEST }}"
+          # Sign using digest instead of tag to avoid timeout issues
+          cosign sign --yes ${{ steps.push.outputs.IMAGE_DIGEST }}

--- a/hack/track-upstream-and-build.yaml
+++ b/hack/track-upstream-and-build.yaml
@@ -1,0 +1,141 @@
+name: Build MeiliSearch MCP Docker Image
+
+on:
+  # Trigger on push to the docker directory (where Dockerfile is maintained)
+  push:
+    paths:
+      - "track-upstream/**"
+      - ".github/workflows/build-meilisearch-mcp.yml"
+
+  # Trigger on manual dispatch
+  workflow_dispatch:
+
+  # Schedule to check upstream repository daily at 2 AM UTC
+  schedule:
+    - cron: "0 * * * *"
+
+  # Trigger when upstream repository is updated (using repository_dispatch)
+  repository_dispatch:
+    types: [upstream-update]
+
+env:
+  UPSTREAM_REPO: meilisearch/meilisearch-mcp
+  DOCKER_REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/meilisearch-mcp
+
+jobs:
+  check-upstream:
+    runs-on: ubuntu-latest
+    outputs:
+      should_build: ${{ steps.check.outputs.should_build }}
+      upstream_sha: ${{ steps.check.outputs.upstream_sha }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get upstream repository latest commit
+        id: upstream
+        run: |
+          UPSTREAM_SHA=$(curl -s https://api.github.com/repos/${{ env.UPSTREAM_REPO }}/commits/main | jq -r '.sha')
+          echo "sha=$UPSTREAM_SHA" >> $GITHUB_OUTPUT
+          echo "Upstream SHA: $UPSTREAM_SHA"
+
+      - name: Get last built commit SHA
+        id: last_built
+        run: |
+          # Try to get the last built SHA from a file in the repo
+          if [ -f .last_upstream_sha ]; then
+            LAST_SHA=$(cat .last_upstream_sha)
+          else
+            LAST_SHA=""
+          fi
+          echo "sha=$LAST_SHA" >> $GITHUB_OUTPUT
+          echo "Last built SHA: $LAST_SHA"
+
+      - name: Check if build is needed
+        id: check
+        run: |
+          # Build if:
+          # 1. This is a manual trigger or push event
+          # 2. Upstream SHA has changed
+          # 3. We've never built before (no last SHA)
+
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || \
+             [[ "${{ github.event_name }}" == "push" ]] || \
+             [[ "${{ steps.upstream.outputs.sha }}" != "${{ steps.last_built.outputs.sha }}" ]] || \
+             [[ -z "${{ steps.last_built.outputs.sha }}" ]]; then
+            echo "should_build=true" >> $GITHUB_OUTPUT
+            echo "Build needed: true"
+          else
+            echo "should_build=false" >> $GITHUB_OUTPUT
+            echo "Build needed: false"
+          fi
+          echo "upstream_sha=${{ steps.upstream.outputs.sha }}" >> $GITHUB_OUTPUT
+
+  build-and-push:
+    needs: check-upstream
+    if: needs.check-upstream.outputs.should_build == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Clone upstream repository
+        run: |
+          git clone https://github.com/${{ env.UPSTREAM_REPO }}.git upstream-source
+          cd upstream-source
+          git checkout ${{ needs.check-upstream.outputs.upstream_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.DOCKER_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,prefix={{branch}}-,suffix=-{{date 'YYYYMMDD-HHmmss'}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ needs.check-upstream.outputs.upstream_sha }},prefix=upstream-
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./upstream-source
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            UPSTREAM_SHA=${{ needs.check-upstream.outputs.upstream_sha }}
+            BUILD_DATE=${{ github.event.repository.updated_at }}
+
+      - name: Update last built SHA
+        run: |
+          echo "${{ needs.check-upstream.outputs.upstream_sha }}" > .last_upstream_sha
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add .last_upstream_sha
+          git diff --staged --quiet || (git commit -m "Update last built upstream SHA to ${{ needs.check-upstream.outputs.upstream_sha }}" && git push)
+
+      - name: Create release notes
+        if: success()
+        run: |
+          echo "Successfully built Docker image from upstream commit: ${{ needs.check-upstream.outputs.upstream_sha }}" > release-notes.txt
+          echo "Image tags: ${{ steps.meta.outputs.tags }}" >> release-notes.txt
+          echo "Upstream repository: https://github.com/${{ env.UPSTREAM_REPO }}" >> release-notes.txt

--- a/mise-tasks-mcp/.gitignore
+++ b/mise-tasks-mcp/.gitignore
@@ -1,0 +1,52 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual Environment
+venv/
+ENV/
+env/
+.venv
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+.hypothesis/
+
+# Logs
+*.log
+
+# Environment variables
+.env
+.env.local
+
+# MCP
+mcp.json

--- a/mise-tasks-mcp/Dockerfile
+++ b/mise-tasks-mcp/Dockerfile
@@ -1,0 +1,64 @@
+# Multi-stage Dockerfile for mise-tasks-mcp
+
+# Build stage
+FROM python:3.12-slim AS builder
+
+WORKDIR /build
+
+# Copy project files
+COPY pyproject.toml ./
+COPY src/ ./src/
+
+# Install build dependencies
+RUN pip install --no-cache-dir build
+
+# Build the package
+RUN python -m build --wheel
+
+# Runtime stage
+FROM python:3.12-slim
+
+# Install runtime dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        curl \
+        git \
+        ca-certificates && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install mise
+RUN curl https://mise.run | sh && \
+    mv ~/.local/bin/mise /usr/local/bin/mise
+
+# Create non-root user
+RUN useradd -m -u 1000 mcp && \
+    mkdir -p /app && \
+    chown -R mcp:mcp /app
+
+WORKDIR /app
+
+# Copy built wheel from builder
+COPY --from=builder /build/dist/*.whl /tmp/
+
+# Install the package
+RUN pip install --no-cache-dir /tmp/*.whl && \
+    rm /tmp/*.whl
+
+# Switch to non-root user
+USER mcp
+
+# Set environment
+ENV PYTHONUNBUFFERED=1
+ENV MISE_DATA_DIR=/app/.mise
+ENV MISE_CONFIG_DIR=/app/.config/mise
+ENV MISE_CACHE_DIR=/app/.cache/mise
+
+# Create necessary directories
+RUN mkdir -p $MISE_DATA_DIR $MISE_CONFIG_DIR $MISE_CACHE_DIR
+
+# Expose MCP default port (if needed)
+EXPOSE 5000
+
+# Run the server
+CMD ["python", "-m", "mise_tasks_mcp.server"]

--- a/mise-tasks-mcp/Dockerfile.cgr
+++ b/mise-tasks-mcp/Dockerfile.cgr
@@ -1,0 +1,61 @@
+# Chainguard-based multi-stage Dockerfile for mise-tasks-mcp
+
+# Build stage using standard Python image
+FROM python:3.12-slim AS builder
+
+WORKDIR /build
+
+# Copy project files
+COPY pyproject.toml ./
+COPY src/ ./src/
+
+# Install build dependencies
+RUN pip install --no-cache-dir build
+
+# Build the package
+RUN python -m build --wheel
+
+# Runtime stage using Chainguard Python
+FROM cgr.dev/chainguard/python:latest
+
+# Install runtime dependencies including bash for npm compatibility
+USER root
+RUN apk update && \
+    apk add --no-cache \
+        curl \
+        git \
+        bash \
+        ca-certificates && \
+    rm -rf /var/cache/apk/*
+
+# Install mise
+RUN curl https://mise.run | sh && \
+    mv ~/.local/bin/mise /usr/local/bin/mise
+
+# Create app directory
+RUN mkdir -p /app && \
+    chown -R nonroot:nonroot /app
+
+WORKDIR /app
+
+# Copy built wheel from builder
+COPY --from=builder --chown=nonroot:nonroot /build/dist/*.whl /tmp/
+
+# Install the package
+RUN pip install --no-cache-dir /tmp/*.whl && \
+    rm /tmp/*.whl
+
+# Switch to non-root user
+USER nonroot
+
+# Set environment
+ENV PYTHONUNBUFFERED=1
+ENV MISE_DATA_DIR=/app/.mise
+ENV MISE_CONFIG_DIR=/app/.config/mise
+ENV MISE_CACHE_DIR=/app/.cache/mise
+
+# Create necessary directories
+RUN mkdir -p $MISE_DATA_DIR $MISE_CONFIG_DIR $MISE_CACHE_DIR
+
+# Run the server
+ENTRYPOINT ["python", "-m", "mise_tasks_mcp.server"]

--- a/mise-tasks-mcp/LICENSE
+++ b/mise-tasks-mcp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Capten.ai and Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/mise-tasks-mcp/README.md
+++ b/mise-tasks-mcp/README.md
@@ -1,0 +1,120 @@
+# mise-tasks-mcp
+
+MCP (Model Context Protocol) server for mise tasks and configuration management.
+
+## Overview
+
+This MCP server provides a focused set of tools for managing mise environments, tasks, and configuration through a standardized API interface.
+
+## Tools
+
+### Environment Management
+- `set_env` - Set environment variables in mise
+- `get_env` - Get environment variable values
+- `unset_env` - Remove environment variables
+
+### Task Management
+- `task_run` - Execute mise tasks with optional arguments
+- `task_ls` - List available tasks
+- `task_info` - Get detailed information about a specific task
+- `task_edit` - Open a task for editing
+- `task_deps` - List task dependencies
+
+### Configuration
+- `get_config` - Retrieve mise configuration values
+- `current_config` - Show current configuration sources
+
+### Utilities
+- `self_update` - Update mise to the latest or specified version
+- `fmt_config` - Format mise configuration files
+
+## Installation
+
+### Using pip
+
+```bash
+# Create virtual environment
+python -m venv venv
+source venv/bin/activate  # On Windows: venv\Scripts\activate
+
+# Install package
+pip install -e .
+```
+
+### Using Docker
+
+```bash
+# Build standard image
+docker build -t mise-tasks-mcp .
+
+# Or build with Chainguard base (more secure, smaller)
+docker build -f Dockerfile.cgr -t mise-tasks-mcp:cgr .
+
+# Run container
+docker run -it mise-tasks-mcp
+```
+
+## Development
+
+### Setup
+
+```bash
+# Install development dependencies
+pip install -e ".[dev]"
+```
+
+### Testing
+
+```bash
+# Run all tests
+pytest
+
+# Run with coverage
+pytest --cov=mise_tasks_mcp
+
+# Run specific test file
+pytest tests/test_server.py
+pytest tests/test_edge_cases.py
+```
+
+### Project Structure
+
+```
+mise-tasks-mcp/
+├── src/
+│   └── mise_tasks_mcp/
+│       ├── __init__.py
+│       ├── server.py          # Main MCP server implementation
+│       └── utils/
+│           ├── __init__.py
+│           ├── command.py     # Command execution utilities
+│           └── validator.py   # Input validation utilities
+├── tests/
+│   ├── test_server.py        # Main server tests
+│   └── test_edge_cases.py    # Edge case and security tests
+├── Dockerfile                 # Standard Docker image
+├── Dockerfile.cgr            # Chainguard-based Docker image
+├── pyproject.toml            # Package configuration
+└── README.md
+```
+
+## Security
+
+This implementation includes several security features:
+
+- **Input Validation**: All user inputs are validated to prevent injection attacks
+- **Command Injection Prevention**: Special characters are properly escaped
+- **Non-root Execution**: Docker containers run as non-root user
+- **Minimal Docker Images**: Chainguard base image option for reduced attack surface
+
+## Requirements
+
+- Python 3.12+
+- mise CLI installed and available in PATH
+- FastMCP library (mcp[cli])
+
+## License
+
+MIT License - See LICENSE file for details.
+
+Copyright (c) 2024 Capten.ai and Contributors

--- a/mise-tasks-mcp/pyproject.toml
+++ b/mise-tasks-mcp/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "mise-tasks-mcp"
+version = "0.1.0"
+description = "MCP server for mise tasks and configuration management"
+readme = "README.md"
+requires-python = ">=3.12"
+license = {text = "MIT"}
+authors = [
+    {name = "Capten.ai", email = "info@capten.ai"},
+]
+dependencies = [
+    "mcp[cli]>=1.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4.0",
+    "pytest-asyncio>=0.21.0",
+    "pytest-timeout>=2.1.0",
+]
+
+[project.scripts]
+mise-tasks-mcp = "mise_tasks_mcp.server:main"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]

--- a/mise-tasks-mcp/src/mise_tasks_mcp/__init__.py
+++ b/mise-tasks-mcp/src/mise_tasks_mcp/__init__.py
@@ -1,0 +1,3 @@
+"""MCP server for mise tasks and configuration management."""
+
+__version__ = "0.1.0"

--- a/mise-tasks-mcp/src/mise_tasks_mcp/__main__.py
+++ b/mise-tasks-mcp/src/mise_tasks_mcp/__main__.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""Entry point for mise-tasks-mcp when run as a module or standalone."""
+
+from .server import main
+
+if __name__ == "__main__":
+    main()

--- a/mise-tasks-mcp/src/mise_tasks_mcp/server.py
+++ b/mise-tasks-mcp/src/mise_tasks_mcp/server.py
@@ -1,0 +1,507 @@
+#!/usr/bin/env python3
+"""MCP server for mise tasks and configuration management."""
+
+import asyncio
+import json
+import logging
+from typing import Any, Dict, Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from .utils.command import run_mise_command
+from .utils.validator import (
+    validate_env_var_name,
+    validate_task_name,
+    validate_config_key,
+    sanitize_input
+)
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+# Initialize FastMCP server
+mcp = FastMCP("mise-tasks-mcp")
+
+
+# Environment Management Tools
+
+@mcp.tool()
+async def set_env(key: str, value: str, file: Optional[str] = None) -> Dict[str, Any]:
+    """
+    Set an environment variable in mise.
+    
+    Args:
+        key: Environment variable name
+        value: Environment variable value
+        file: Optional file to update (.env or .mise.toml)
+        
+    Returns:
+        Operation result with status
+    """
+    if not validate_env_var_name(key):
+        return {
+            "success": False,
+            "error": f"Invalid environment variable name: {key}"
+        }
+    
+    args = ["env", "set"]
+    if file:
+        args.extend(["--file", file])
+    args.extend([key, value])
+    
+    result = await run_mise_command("", args)
+    
+    return {
+        "success": result.success,
+        "key": key,
+        "value": value,
+        "output": result.output if result.success else None,
+        "error": result.error if not result.success else None
+    }
+
+
+@mcp.tool()
+async def get_env(key: Optional[str] = None) -> Dict[str, Any]:
+    """
+    Get environment variable(s) from mise.
+    
+    Args:
+        key: Optional specific environment variable to get
+        
+    Returns:
+        Environment variable(s) and their values
+    """
+    if key and not validate_env_var_name(key):
+        return {
+            "success": False,
+            "error": f"Invalid environment variable name: {key}"
+        }
+    
+    if key:
+        args = ["env", "get", key]
+    else:
+        args = ["env"]
+    
+    result = await run_mise_command("", args)
+    
+    if result.success:
+        if key:
+            # Single variable
+            return {
+                "success": True,
+                "key": key,
+                "value": result.output
+            }
+        else:
+            # Parse all variables
+            env_vars = {}
+            for line in result.output.split('\n'):
+                if '=' in line:
+                    k, v = line.split('=', 1)
+                    env_vars[k] = v
+            return {
+                "success": True,
+                "variables": env_vars
+            }
+    else:
+        return {
+            "success": False,
+            "error": result.error
+        }
+
+
+@mcp.tool()
+async def unset_env(key: str, file: Optional[str] = None) -> Dict[str, Any]:
+    """
+    Unset an environment variable in mise.
+    
+    Args:
+        key: Environment variable name to unset
+        file: Optional file to update (.env or .mise.toml)
+        
+    Returns:
+        Operation result with status
+    """
+    if not validate_env_var_name(key):
+        return {
+            "success": False,
+            "error": f"Invalid environment variable name: {key}"
+        }
+    
+    args = ["env", "unset"]
+    if file:
+        args.extend(["--file", file])
+    args.append(key)
+    
+    result = await run_mise_command("", args)
+    
+    return {
+        "success": result.success,
+        "key": key,
+        "output": result.output if result.success else None,
+        "error": result.error if not result.success else None
+    }
+
+
+# Task Management Tools
+
+@mcp.tool()
+async def task_run(task: str, args: Optional[str] = None, cd: Optional[str] = None) -> Dict[str, Any]:
+    """
+    Run a mise task.
+    
+    Args:
+        task: Task name to run
+        args: Optional arguments to pass to the task
+        cd: Optional directory to run the task in
+        
+    Returns:
+        Task execution result
+    """
+    if not validate_task_name(task):
+        return {
+            "success": False,
+            "error": f"Invalid task name: {task}"
+        }
+    
+    cmd_args = ["tasks", "run"]
+    if cd:
+        cmd_args.extend(["--cd", cd])
+    cmd_args.append(task)
+    
+    if args:
+        # Split args and add them
+        cmd_args.extend(args.split())
+    
+    result = await run_mise_command("", cmd_args, timeout=60.0)
+    
+    return {
+        "success": result.success,
+        "task": task,
+        "output": result.output,
+        "error": result.error if not result.success else None,
+        "return_code": result.return_code
+    }
+
+
+@mcp.tool()
+async def task_ls(hidden: bool = False) -> Dict[str, Any]:
+    """
+    List available mise tasks.
+    
+    Args:
+        hidden: Include hidden tasks
+        
+    Returns:
+        List of available tasks with descriptions
+    """
+    args = ["tasks", "ls"]
+    if hidden:
+        args.append("--hidden")
+    
+    result = await run_mise_command("", args)
+    
+    if result.success:
+        # Parse task list
+        tasks = []
+        for line in result.output.split('\n'):
+            if line.strip():
+                # Tasks are typically formatted as "name description"
+                parts = line.split(None, 1)
+                if parts:
+                    task_info = {"name": parts[0]}
+                    if len(parts) > 1:
+                        task_info["description"] = parts[1]
+                    tasks.append(task_info)
+        
+        return {
+            "success": True,
+            "tasks": tasks,
+            "count": len(tasks)
+        }
+    else:
+        return {
+            "success": False,
+            "error": result.error
+        }
+
+
+@mcp.tool()
+async def task_info(task: str) -> Dict[str, Any]:
+    """
+    Get detailed information about a specific task.
+    
+    Args:
+        task: Task name to get info for
+        
+    Returns:
+        Detailed task information
+    """
+    if not validate_task_name(task):
+        return {
+            "success": False,
+            "error": f"Invalid task name: {task}"
+        }
+    
+    args = ["tasks", "info", task]
+    result = await run_mise_command("", args)
+    
+    if result.success:
+        # Parse task info
+        info = {
+            "name": task,
+            "raw_output": result.output
+        }
+        
+        # Try to extract structured info from output
+        lines = result.output.split('\n')
+        for line in lines:
+            if ':' in line:
+                key, value = line.split(':', 1)
+                key = key.strip().lower().replace(' ', '_')
+                info[key] = value.strip()
+        
+        return {
+            "success": True,
+            "task_info": info
+        }
+    else:
+        return {
+            "success": False,
+            "error": result.error
+        }
+
+
+@mcp.tool()
+async def task_edit(task: str, editor: Optional[str] = None) -> Dict[str, Any]:
+    """
+    Open a task for editing in the configured editor.
+    
+    Args:
+        task: Task name to edit
+        editor: Optional editor to use (defaults to $EDITOR)
+        
+    Returns:
+        Status of the edit operation
+    """
+    if not validate_task_name(task):
+        return {
+            "success": False,
+            "error": f"Invalid task name: {task}"
+        }
+    
+    args = ["tasks", "edit", task]
+    
+    env = {}
+    if editor:
+        env["EDITOR"] = editor
+    
+    # Note: This might open an interactive editor
+    result = await run_mise_command("", args, env=env if env else None)
+    
+    return {
+        "success": result.success,
+        "task": task,
+        "message": "Task opened for editing" if result.success else None,
+        "error": result.error if not result.success else None
+    }
+
+
+@mcp.tool()
+async def task_deps(task: str) -> Dict[str, Any]:
+    """
+    List dependencies for a specific task.
+    
+    Args:
+        task: Task name to get dependencies for
+        
+    Returns:
+        List of task dependencies
+    """
+    if not validate_task_name(task):
+        return {
+            "success": False,
+            "error": f"Invalid task name: {task}"
+        }
+    
+    args = ["tasks", "deps", task]
+    result = await run_mise_command("", args)
+    
+    if result.success:
+        # Parse dependencies
+        deps = []
+        for line in result.output.split('\n'):
+            if line.strip():
+                deps.append(line.strip())
+        
+        return {
+            "success": True,
+            "task": task,
+            "dependencies": deps,
+            "count": len(deps)
+        }
+    else:
+        return {
+            "success": False,
+            "error": result.error
+        }
+
+
+# Configuration Tools
+
+@mcp.tool()
+async def get_config(key: Optional[str] = None) -> Dict[str, Any]:
+    """
+    Get mise configuration value(s).
+    
+    Args:
+        key: Optional specific configuration key to get
+        
+    Returns:
+        Configuration value(s)
+    """
+    if key and not validate_config_key(key):
+        return {
+            "success": False,
+            "error": f"Invalid configuration key: {key}"
+        }
+    
+    args = ["config", "get"]
+    if key:
+        args.append(key)
+    
+    result = await run_mise_command("", args)
+    
+    if result.success:
+        if key:
+            return {
+                "success": True,
+                "key": key,
+                "value": result.output
+            }
+        else:
+            # Try to parse as JSON for full config
+            try:
+                config = json.loads(result.output)
+                return {
+                    "success": True,
+                    "config": config
+                }
+            except json.JSONDecodeError:
+                # Return raw output if not JSON
+                return {
+                    "success": True,
+                    "raw_config": result.output
+                }
+    else:
+        return {
+            "success": False,
+            "error": result.error
+        }
+
+
+@mcp.tool()
+async def current_config() -> Dict[str, Any]:
+    """
+    Show current mise configuration with sources.
+    
+    Returns:
+        Current configuration and its sources
+    """
+    args = ["config", "ls"]
+    result = await run_mise_command("", args)
+    
+    if result.success:
+        # Parse config sources
+        config_files = []
+        for line in result.output.split('\n'):
+            if line.strip():
+                config_files.append(line.strip())
+        
+        return {
+            "success": True,
+            "config_files": config_files,
+            "count": len(config_files)
+        }
+    else:
+        return {
+            "success": False,
+            "error": result.error
+        }
+
+
+# Utility Tools
+
+@mcp.tool()
+async def self_update(version: Optional[str] = None, force: bool = False) -> Dict[str, Any]:
+    """
+    Update mise CLI to the latest or specified version.
+    
+    Args:
+        version: Optional specific version to update to
+        force: Force update even if already on latest
+        
+    Returns:
+        Update status and version information
+    """
+    args = ["self-update"]
+    if version:
+        args.append(version)
+    if force:
+        args.append("--force")
+    
+    result = await run_mise_command("", args, timeout=120.0)
+    
+    return {
+        "success": result.success,
+        "output": result.output,
+        "error": result.error if not result.success else None
+    }
+
+
+@mcp.tool()
+async def fmt_config(path: Optional[str] = None) -> Dict[str, Any]:
+    """
+    Format mise configuration files.
+    
+    Args:
+        path: Optional specific path to format (defaults to current directory)
+        
+    Returns:
+        Format operation result
+    """
+    args = ["fmt"]
+    if path:
+        args.append(path)
+    
+    result = await run_mise_command("", args)
+    
+    return {
+        "success": result.success,
+        "formatted_files": result.output.split('\n') if result.success and result.output else [],
+        "error": result.error if not result.success else None
+    }
+
+
+# Main entry point
+def main():
+    """Run the MCP server."""
+    import sys
+    
+    try:
+        logger.info("Starting mise-tasks-mcp server...")
+        mcp.run()
+    except KeyboardInterrupt:
+        logger.info("Server stopped by user")
+        sys.exit(0)
+    except Exception as e:
+        logger.error(f"Server error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/mise-tasks-mcp/src/mise_tasks_mcp/utils/__init__.py
+++ b/mise-tasks-mcp/src/mise_tasks_mcp/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility modules for mise-tasks-mcp."""

--- a/mise-tasks-mcp/src/mise_tasks_mcp/utils/command.py
+++ b/mise-tasks-mcp/src/mise_tasks_mcp/utils/command.py
@@ -1,0 +1,92 @@
+"""Command execution utilities for mise-tasks-mcp."""
+
+import asyncio
+import shutil
+from dataclasses import dataclass
+from typing import List, Optional
+import os
+
+
+@dataclass
+class CommandResult:
+    """Result of a command execution."""
+    
+    success: bool
+    output: str
+    error: str
+    return_code: int
+
+
+async def run_mise_command(
+    command: str, 
+    args: Optional[List[str]] = None,
+    timeout: float = 30.0,
+    env: Optional[dict] = None
+) -> CommandResult:
+    """
+    Execute a mise command asynchronously.
+    
+    Args:
+        command: The mise subcommand to run
+        args: Optional list of arguments for the command
+        timeout: Timeout in seconds for command execution
+        env: Optional environment variables to set
+        
+    Returns:
+        CommandResult containing the outcome of the command
+    """
+    mise_path = shutil.which("mise")
+    if not mise_path:
+        return CommandResult(
+            success=False,
+            output="",
+            error="mise CLI not found in PATH",
+            return_code=1
+        )
+    
+    cmd_parts = [mise_path, command]
+    if args:
+        cmd_parts.extend(args)
+    
+    # Prepare environment
+    cmd_env = os.environ.copy()
+    if env:
+        cmd_env.update(env)
+    
+    try:
+        process = await asyncio.create_subprocess_exec(
+            *cmd_parts,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=cmd_env
+        )
+        
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                process.communicate(),
+                timeout=timeout
+            )
+        except asyncio.TimeoutError:
+            process.kill()
+            await process.wait()
+            return CommandResult(
+                success=False,
+                output="",
+                error=f"Command timed out after {timeout} seconds",
+                return_code=-1
+            )
+        
+        return CommandResult(
+            success=process.returncode == 0,
+            output=stdout.decode("utf-8", errors="replace").strip(),
+            error=stderr.decode("utf-8", errors="replace").strip(),
+            return_code=process.returncode or 0
+        )
+        
+    except Exception as e:
+        return CommandResult(
+            success=False,
+            output="",
+            error=f"Failed to execute command: {str(e)}",
+            return_code=1
+        )

--- a/mise-tasks-mcp/src/mise_tasks_mcp/utils/validator.py
+++ b/mise-tasks-mcp/src/mise_tasks_mcp/utils/validator.py
@@ -1,0 +1,87 @@
+"""Input validation utilities for mise-tasks-mcp."""
+
+import re
+from typing import Any, Optional
+
+
+def validate_env_var_name(name: str) -> bool:
+    """
+    Validate environment variable name.
+    
+    Args:
+        name: The environment variable name to validate
+        
+    Returns:
+        True if the name is valid, False otherwise
+    """
+    if not name:
+        return False
+    
+    # Must start with letter or underscore, followed by letters, numbers, or underscores
+    pattern = r'^[a-zA-Z_][a-zA-Z0-9_]*$'
+    return bool(re.match(pattern, name))
+
+
+def validate_task_name(name: str) -> bool:
+    """
+    Validate task name format.
+    
+    Args:
+        name: The task name to validate
+        
+    Returns:
+        True if the name is valid, False otherwise
+    """
+    if not name:
+        return False
+    
+    # Task names can contain alphanumeric, dash, underscore, colon, dot
+    pattern = r'^[a-zA-Z0-9_\-:\.]+$'
+    return bool(re.match(pattern, name))
+
+
+def sanitize_input(value: Any) -> str:
+    """
+    Sanitize input to prevent injection attacks.
+    
+    Args:
+        value: The value to sanitize
+        
+    Returns:
+        Sanitized string value
+    """
+    if value is None:
+        return ""
+    
+    # Convert to string
+    str_value = str(value)
+    
+    # Remove null bytes
+    str_value = str_value.replace('\x00', '')
+    
+    # Escape shell special characters
+    # First escape backslashes, then other characters
+    str_value = str_value.replace('\\', '\\\\')
+    dangerous_chars = ['`', '$', '&', '|', ';', '<', '>', '(', ')', '{', '}', '[', ']', '"', "'", '\n', '\r']
+    for char in dangerous_chars:
+        str_value = str_value.replace(char, f'\\{char}')
+    
+    return str_value
+
+
+def validate_config_key(key: str) -> bool:
+    """
+    Validate configuration key format.
+    
+    Args:
+        key: The configuration key to validate
+        
+    Returns:
+        True if the key is valid, False otherwise
+    """
+    if not key:
+        return False
+    
+    # Config keys are typically dot-separated paths
+    pattern = r'^[a-zA-Z0-9_\-]+(\.?[a-zA-Z0-9_\-]+)*$'
+    return bool(re.match(pattern, key))

--- a/mise-tasks-mcp/tests/test_edge_cases.py
+++ b/mise-tasks-mcp/tests/test_edge_cases.py
@@ -1,0 +1,303 @@
+"""Edge case tests for mise-tasks-mcp server."""
+
+import pytest
+from unittest.mock import patch
+from mise_tasks_mcp.server import (
+    set_env, get_env, unset_env,
+    task_run, task_ls, task_info,
+    get_config, fmt_config
+)
+from mise_tasks_mcp.utils.command import CommandResult
+from mise_tasks_mcp.utils.validator import (
+    validate_env_var_name,
+    validate_task_name,
+    validate_config_key,
+    sanitize_input
+)
+
+
+class TestValidatorEdgeCases:
+    """Test edge cases for validators."""
+    
+    def test_env_var_name_validation(self):
+        """Test environment variable name validation edge cases."""
+        # Valid cases
+        assert validate_env_var_name("PATH") is True
+        assert validate_env_var_name("_PRIVATE") is True
+        assert validate_env_var_name("VAR_123") is True
+        assert validate_env_var_name("__DOUBLE__") is True
+        
+        # Invalid cases
+        assert validate_env_var_name("") is False
+        assert validate_env_var_name("123START") is False
+        assert validate_env_var_name("VAR-DASH") is False
+        assert validate_env_var_name("VAR SPACE") is False
+        assert validate_env_var_name("VAR.DOT") is False
+        assert validate_env_var_name("VAR$SPECIAL") is False
+    
+    def test_task_name_validation(self):
+        """Test task name validation edge cases."""
+        # Valid cases
+        assert validate_task_name("build") is True
+        assert validate_task_name("test:unit") is True
+        assert validate_task_name("deploy-prod") is True
+        assert validate_task_name("pre.commit") is True
+        assert validate_task_name("task_123") is True
+        
+        # Invalid cases
+        assert validate_task_name("") is False
+        assert validate_task_name("task with space") is False
+        assert validate_task_name("task$special") is False
+        assert validate_task_name("task;injection") is False
+    
+    def test_config_key_validation(self):
+        """Test config key validation edge cases."""
+        # Valid cases
+        assert validate_config_key("experimental") is True
+        assert validate_config_key("legacy_version_file") is True
+        assert validate_config_key("node.version") is True
+        assert validate_config_key("python-version") is True
+        
+        # Invalid cases
+        assert validate_config_key("") is False
+        assert validate_config_key(".startdot") is False
+        assert validate_config_key("enddot.") is False
+        assert validate_config_key("key..double") is False
+        assert validate_config_key("key with space") is False
+    
+    def test_sanitize_input(self):
+        """Test input sanitization."""
+        # Test None
+        assert sanitize_input(None) == ""
+        
+        # Test shell special characters
+        assert sanitize_input("test`command`") == "test\\`command\\`"
+        assert sanitize_input("$VAR") == "\\$VAR"
+        assert sanitize_input("cmd && other") == "cmd \\&\\& other"
+        assert sanitize_input("cmd | pipe") == "cmd \\| pipe"
+        assert sanitize_input("cmd; injection") == "cmd\\; injection"
+        
+        # Test null bytes
+        assert sanitize_input("test\x00null") == "testnull"
+        
+        # Test quotes
+        assert sanitize_input('test "quoted"') == 'test \\"quoted\\"'
+        assert sanitize_input("test 'single'") == "test \\'single\\'"
+
+
+class TestEnvironmentEdgeCases:
+    """Edge case tests for environment tools."""
+    
+    @pytest.mark.asyncio
+    async def test_set_env_empty_value(self):
+        """Test setting env var with empty value."""
+        with patch('mise_tasks_mcp.server.run_mise_command') as mock:
+            mock.return_value = CommandResult(
+                success=True, output="", error="", return_code=0
+            )
+            
+            result = await set_env("EMPTY_VAR", "")
+            assert result["success"] is True
+            assert result["value"] == ""
+    
+    @pytest.mark.asyncio
+    async def test_set_env_special_chars_in_value(self):
+        """Test setting env var with special characters."""
+        with patch('mise_tasks_mcp.server.run_mise_command') as mock:
+            mock.return_value = CommandResult(
+                success=True, output="", error="", return_code=0
+            )
+            
+            result = await set_env("VAR", "value with spaces and $pecial")
+            assert result["success"] is True
+    
+    @pytest.mark.asyncio
+    async def test_get_env_nonexistent(self):
+        """Test getting non-existent env var."""
+        with patch('mise_tasks_mcp.server.run_mise_command') as mock:
+            mock.return_value = CommandResult(
+                success=False,
+                output="",
+                error="Environment variable not found",
+                return_code=1
+            )
+            
+            result = await get_env("NONEXISTENT")
+            assert result["success"] is False
+            assert "not found" in result["error"]
+    
+    @pytest.mark.asyncio
+    async def test_get_env_empty_response(self):
+        """Test getting env with empty response."""
+        with patch('mise_tasks_mcp.server.run_mise_command') as mock:
+            mock.return_value = CommandResult(
+                success=True, output="", error="", return_code=0
+            )
+            
+            result = await get_env()
+            assert result["success"] is True
+            assert result["variables"] == {}
+
+
+class TestTaskEdgeCases:
+    """Edge case tests for task tools."""
+    
+    @pytest.mark.asyncio
+    async def test_task_run_timeout(self):
+        """Test task run with timeout."""
+        with patch('mise_tasks_mcp.server.run_mise_command') as mock:
+            mock.return_value = CommandResult(
+                success=False,
+                output="",
+                error="Command timed out after 60.0 seconds",
+                return_code=-1
+            )
+            
+            result = await task_run("long-running-task")
+            assert result["success"] is False
+            assert "timed out" in result["error"]
+    
+    @pytest.mark.asyncio
+    async def test_task_run_with_spaces_in_args(self):
+        """Test task run with spaces in arguments."""
+        with patch('mise_tasks_mcp.server.run_mise_command') as mock:
+            mock.return_value = CommandResult(
+                success=True, output="Done", error="", return_code=0
+            )
+            
+            result = await task_run("test", args='--message "hello world"')
+            assert result["success"] is True
+    
+    @pytest.mark.asyncio
+    async def test_task_ls_no_tasks(self):
+        """Test listing tasks when none exist."""
+        with patch('mise_tasks_mcp.server.run_mise_command') as mock:
+            mock.return_value = CommandResult(
+                success=True, output="", error="", return_code=0
+            )
+            
+            result = await task_ls()
+            assert result["success"] is True
+            assert result["count"] == 0
+            assert result["tasks"] == []
+    
+    @pytest.mark.asyncio
+    async def test_task_info_malformed_output(self):
+        """Test task info with malformed output."""
+        with patch('mise_tasks_mcp.server.run_mise_command') as mock:
+            mock.return_value = CommandResult(
+                success=True,
+                output="Some malformed output without colons",
+                error="",
+                return_code=0
+            )
+            
+            result = await task_info("test")
+            assert result["success"] is True
+            assert result["task_info"]["name"] == "test"
+            assert "raw_output" in result["task_info"]
+
+
+class TestConfigEdgeCases:
+    """Edge case tests for config tools."""
+    
+    @pytest.mark.asyncio
+    async def test_get_config_invalid_json(self):
+        """Test get config with invalid JSON response."""
+        with patch('mise_tasks_mcp.server.run_mise_command') as mock:
+            mock.return_value = CommandResult(
+                success=True,
+                output="Not valid JSON {broken",
+                error="",
+                return_code=0
+            )
+            
+            result = await get_config()
+            assert result["success"] is True
+            assert "raw_config" in result
+            assert result["raw_config"] == "Not valid JSON {broken"
+    
+    @pytest.mark.asyncio
+    async def test_get_config_nested_key(self):
+        """Test getting nested config key."""
+        with patch('mise_tasks_mcp.server.run_mise_command') as mock:
+            mock.return_value = CommandResult(
+                success=True,
+                output="value123",
+                error="",
+                return_code=0
+            )
+            
+            result = await get_config("tools.node.version")
+            assert result["success"] is True
+            assert result["key"] == "tools.node.version"
+            assert result["value"] == "value123"
+
+
+class TestUtilityEdgeCases:
+    """Edge case tests for utility tools."""
+    
+    @pytest.mark.asyncio
+    async def test_fmt_config_no_files(self):
+        """Test formatting when no files to format."""
+        with patch('mise_tasks_mcp.server.run_mise_command') as mock:
+            mock.return_value = CommandResult(
+                success=True, output="", error="", return_code=0
+            )
+            
+            result = await fmt_config()
+            assert result["success"] is True
+            assert result["formatted_files"] == []
+    
+    @pytest.mark.asyncio
+    async def test_fmt_config_with_path(self):
+        """Test formatting with specific path."""
+        with patch('mise_tasks_mcp.server.run_mise_command') as mock:
+            mock.return_value = CommandResult(
+                success=True,
+                output="formatted: /path/to/.mise.toml",
+                error="",
+                return_code=0
+            )
+            
+            result = await fmt_config("/path/to")
+            assert result["success"] is True
+            assert len(result["formatted_files"]) == 1
+
+
+class TestCommandInjectionPrevention:
+    """Test prevention of command injection attacks."""
+    
+    @pytest.mark.asyncio
+    async def test_env_injection_attempt(self):
+        """Test that env var names prevent injection."""
+        # These should fail validation
+        result = await set_env("VAR; rm -rf /", "value")
+        assert result["success"] is False
+        
+        result = await set_env("VAR`cmd`", "value")
+        assert result["success"] is False
+        
+        result = await set_env("VAR$(cmd)", "value")
+        assert result["success"] is False
+    
+    @pytest.mark.asyncio
+    async def test_task_injection_attempt(self):
+        """Test that task names prevent injection."""
+        result = await task_run("task; rm -rf /")
+        assert result["success"] is False
+        
+        result = await task_run("task`cmd`")
+        assert result["success"] is False
+        
+        result = await task_run("task$(cmd)")
+        assert result["success"] is False
+    
+    @pytest.mark.asyncio
+    async def test_config_injection_attempt(self):
+        """Test that config keys prevent injection."""
+        result = await get_config("key; cat /etc/passwd")
+        assert result["success"] is False
+        
+        result = await get_config("key`cmd`")
+        assert result["success"] is False

--- a/mise-tasks-mcp/tests/test_integration.py
+++ b/mise-tasks-mcp/tests/test_integration.py
@@ -1,0 +1,122 @@
+"""Integration tests for mise-tasks-mcp server with actual mise commands."""
+
+import pytest
+import shutil
+from mise_tasks_mcp.server import (
+    set_env, get_env, unset_env,
+    task_run, task_ls, task_info,
+    get_config, current_config,
+    self_update, fmt_config
+)
+
+
+# Skip all tests if mise is not installed
+pytestmark = pytest.mark.skipif(
+    not shutil.which("mise"),
+    reason="mise CLI not installed"
+)
+
+
+class TestEnvironmentIntegration:
+    """Integration tests for environment tools."""
+    
+    @pytest.mark.asyncio
+    async def test_env_workflow(self):
+        """Test complete environment variable workflow."""
+        # Set a test variable
+        result = await set_env("MISE_TEST_VAR", "test_value_123")
+        if result["success"]:
+            # Get the variable
+            get_result = await get_env("MISE_TEST_VAR")
+            assert get_result["success"] is True
+            
+            # Unset the variable
+            unset_result = await unset_env("MISE_TEST_VAR")
+            assert unset_result["success"] is True
+    
+    @pytest.mark.asyncio
+    async def test_get_all_env(self):
+        """Test getting all environment variables."""
+        result = await get_env()
+        # Should at least be able to call it
+        assert isinstance(result, dict)
+        assert "success" in result
+
+
+class TestTaskIntegration:
+    """Integration tests for task tools."""
+    
+    @pytest.mark.asyncio
+    async def test_list_tasks(self):
+        """Test listing tasks."""
+        result = await task_ls()
+        assert isinstance(result, dict)
+        assert "success" in result
+        if result["success"]:
+            assert "tasks" in result
+            assert isinstance(result["tasks"], list)
+    
+    @pytest.mark.asyncio
+    async def test_list_tasks_with_hidden(self):
+        """Test listing tasks including hidden ones."""
+        result = await task_ls(hidden=True)
+        assert isinstance(result, dict)
+        assert "success" in result
+
+
+class TestConfigIntegration:
+    """Integration tests for config tools."""
+    
+    @pytest.mark.asyncio
+    async def test_get_config_all(self):
+        """Test getting all config."""
+        result = await get_config()
+        assert isinstance(result, dict)
+        assert "success" in result
+    
+    @pytest.mark.asyncio
+    async def test_current_config_files(self):
+        """Test listing config files."""
+        result = await current_config()
+        assert isinstance(result, dict)
+        assert "success" in result
+        if result["success"]:
+            assert "config_files" in result
+            assert isinstance(result["config_files"], list)
+
+
+class TestEdgeCasesWithRealCommands:
+    """Test edge cases with real mise commands."""
+    
+    @pytest.mark.asyncio
+    async def test_invalid_task_name(self):
+        """Test running non-existent task."""
+        result = await task_run("nonexistent_task_xyz_123")
+        # Should fail gracefully
+        assert result["success"] is False
+    
+    @pytest.mark.asyncio
+    async def test_env_var_with_special_chars(self):
+        """Test environment variable with special characters in value."""
+        # Set variable with spaces and special chars
+        result = await set_env("MISE_TEST_SPECIAL", "value with spaces & symbols!")
+        if result["success"]:
+            # Clean up
+            await unset_env("MISE_TEST_SPECIAL")
+    
+    @pytest.mark.asyncio
+    async def test_empty_env_value(self):
+        """Test setting empty environment variable."""
+        result = await set_env("MISE_TEST_EMPTY", "")
+        if result["success"]:
+            # Clean up
+            await unset_env("MISE_TEST_EMPTY")
+    
+    @pytest.mark.asyncio
+    async def test_very_long_env_value(self):
+        """Test environment variable with very long value."""
+        long_value = "x" * 1000
+        result = await set_env("MISE_TEST_LONG", long_value)
+        if result["success"]:
+            # Clean up
+            await unset_env("MISE_TEST_LONG")

--- a/mise-tasks-mcp/tests/test_server.py
+++ b/mise-tasks-mcp/tests/test_server.py
@@ -1,0 +1,306 @@
+"""Tests for mise-tasks-mcp server tools."""
+
+import pytest
+from unittest.mock import patch, AsyncMock
+from mise_tasks_mcp.server import (
+    set_env, get_env, unset_env,
+    task_run, task_ls, task_info, task_edit, task_deps,
+    get_config, current_config,
+    self_update, fmt_config
+)
+from mise_tasks_mcp.utils.command import CommandResult
+
+
+@pytest.fixture
+def mock_run_mise_command():
+    """Mock the run_mise_command function."""
+    with patch('mise_tasks_mcp.server.run_mise_command') as mock:
+        yield mock
+
+
+class TestEnvironmentTools:
+    """Tests for environment management tools."""
+    
+    @pytest.mark.asyncio
+    async def test_set_env(self, mock_run_mise_command):
+        """Test setting an environment variable."""
+        mock_run_mise_command.return_value = CommandResult(
+            success=True,
+            output="Environment variable set",
+            error="",
+            return_code=0
+        )
+        
+        result = await set_env("TEST_VAR", "test_value")
+        
+        assert result["success"] is True
+        assert result["key"] == "TEST_VAR"
+        assert result["value"] == "test_value"
+        mock_run_mise_command.assert_called_once()
+    
+    @pytest.mark.asyncio
+    async def test_set_env_invalid_name(self):
+        """Test setting env var with invalid name."""
+        result = await set_env("123-invalid", "value")
+        
+        assert result["success"] is False
+        assert "Invalid environment variable name" in result["error"]
+    
+    @pytest.mark.asyncio
+    async def test_get_env_single(self, mock_run_mise_command):
+        """Test getting a single environment variable."""
+        mock_run_mise_command.return_value = CommandResult(
+            success=True,
+            output="test_value",
+            error="",
+            return_code=0
+        )
+        
+        result = await get_env("TEST_VAR")
+        
+        assert result["success"] is True
+        assert result["key"] == "TEST_VAR"
+        assert result["value"] == "test_value"
+    
+    @pytest.mark.asyncio
+    async def test_get_env_all(self, mock_run_mise_command):
+        """Test getting all environment variables."""
+        mock_run_mise_command.return_value = CommandResult(
+            success=True,
+            output="VAR1=value1\nVAR2=value2",
+            error="",
+            return_code=0
+        )
+        
+        result = await get_env()
+        
+        assert result["success"] is True
+        assert result["variables"] == {"VAR1": "value1", "VAR2": "value2"}
+    
+    @pytest.mark.asyncio
+    async def test_unset_env(self, mock_run_mise_command):
+        """Test unsetting an environment variable."""
+        mock_run_mise_command.return_value = CommandResult(
+            success=True,
+            output="Environment variable unset",
+            error="",
+            return_code=0
+        )
+        
+        result = await unset_env("TEST_VAR")
+        
+        assert result["success"] is True
+        assert result["key"] == "TEST_VAR"
+        mock_run_mise_command.assert_called_once()
+
+
+class TestTaskTools:
+    """Tests for task management tools."""
+    
+    @pytest.mark.asyncio
+    async def test_task_run(self, mock_run_mise_command):
+        """Test running a task."""
+        mock_run_mise_command.return_value = CommandResult(
+            success=True,
+            output="Task completed successfully",
+            error="",
+            return_code=0
+        )
+        
+        result = await task_run("build")
+        
+        assert result["success"] is True
+        assert result["task"] == "build"
+        assert "completed successfully" in result["output"]
+    
+    @pytest.mark.asyncio
+    async def test_task_run_with_args(self, mock_run_mise_command):
+        """Test running a task with arguments."""
+        mock_run_mise_command.return_value = CommandResult(
+            success=True,
+            output="Test passed",
+            error="",
+            return_code=0
+        )
+        
+        result = await task_run("test", args="--verbose --coverage")
+        
+        assert result["success"] is True
+        assert result["task"] == "test"
+        mock_run_mise_command.assert_called_once()
+        # Check that args were passed
+        call_args = mock_run_mise_command.call_args[0]
+        assert "--verbose" in call_args[1]
+        assert "--coverage" in call_args[1]
+    
+    @pytest.mark.asyncio
+    async def test_task_ls(self, mock_run_mise_command):
+        """Test listing tasks."""
+        mock_run_mise_command.return_value = CommandResult(
+            success=True,
+            output="build Build the project\ntest Run tests\nlint Run linter",
+            error="",
+            return_code=0
+        )
+        
+        result = await task_ls()
+        
+        assert result["success"] is True
+        assert result["count"] == 3
+        assert len(result["tasks"]) == 3
+        assert result["tasks"][0]["name"] == "build"
+    
+    @pytest.mark.asyncio
+    async def test_task_info(self, mock_run_mise_command):
+        """Test getting task info."""
+        mock_run_mise_command.return_value = CommandResult(
+            success=True,
+            output="Name: build\nDescription: Build project\nCommand: npm run build",
+            error="",
+            return_code=0
+        )
+        
+        result = await task_info("build")
+        
+        assert result["success"] is True
+        assert result["task_info"]["name"] == "build"
+        assert "description" in result["task_info"]
+    
+    @pytest.mark.asyncio
+    async def test_task_edit(self, mock_run_mise_command):
+        """Test editing a task."""
+        mock_run_mise_command.return_value = CommandResult(
+            success=True,
+            output="",
+            error="",
+            return_code=0
+        )
+        
+        result = await task_edit("build")
+        
+        assert result["success"] is True
+        assert result["task"] == "build"
+        assert result["message"] == "Task opened for editing"
+    
+    @pytest.mark.asyncio
+    async def test_task_deps(self, mock_run_mise_command):
+        """Test getting task dependencies."""
+        mock_run_mise_command.return_value = CommandResult(
+            success=True,
+            output="install\ncompile\ntest",
+            error="",
+            return_code=0
+        )
+        
+        result = await task_deps("build")
+        
+        assert result["success"] is True
+        assert result["task"] == "build"
+        assert result["count"] == 3
+        assert "install" in result["dependencies"]
+
+
+class TestConfigTools:
+    """Tests for configuration tools."""
+    
+    @pytest.mark.asyncio
+    async def test_get_config_key(self, mock_run_mise_command):
+        """Test getting a specific config value."""
+        mock_run_mise_command.return_value = CommandResult(
+            success=True,
+            output="true",
+            error="",
+            return_code=0
+        )
+        
+        result = await get_config("experimental")
+        
+        assert result["success"] is True
+        assert result["key"] == "experimental"
+        assert result["value"] == "true"
+    
+    @pytest.mark.asyncio
+    async def test_get_config_all(self, mock_run_mise_command):
+        """Test getting all config."""
+        mock_run_mise_command.return_value = CommandResult(
+            success=True,
+            output='{"experimental": true, "legacy_version_file": false}',
+            error="",
+            return_code=0
+        )
+        
+        result = await get_config()
+        
+        assert result["success"] is True
+        assert result["config"]["experimental"] is True
+        assert result["config"]["legacy_version_file"] is False
+    
+    @pytest.mark.asyncio
+    async def test_current_config(self, mock_run_mise_command):
+        """Test getting current config sources."""
+        mock_run_mise_command.return_value = CommandResult(
+            success=True,
+            output="/home/user/.config/mise/config.toml\n/home/user/project/.mise.toml",
+            error="",
+            return_code=0
+        )
+        
+        result = await current_config()
+        
+        assert result["success"] is True
+        assert result["count"] == 2
+        assert len(result["config_files"]) == 2
+
+
+class TestUtilityTools:
+    """Tests for utility tools."""
+    
+    @pytest.mark.asyncio
+    async def test_self_update(self, mock_run_mise_command):
+        """Test self-update."""
+        mock_run_mise_command.return_value = CommandResult(
+            success=True,
+            output="Updated to version 2024.1.0",
+            error="",
+            return_code=0
+        )
+        
+        result = await self_update()
+        
+        assert result["success"] is True
+        assert "Updated to version" in result["output"]
+    
+    @pytest.mark.asyncio
+    async def test_self_update_with_version(self, mock_run_mise_command):
+        """Test self-update to specific version."""
+        mock_run_mise_command.return_value = CommandResult(
+            success=True,
+            output="Updated to version 2023.12.0",
+            error="",
+            return_code=0
+        )
+        
+        result = await self_update(version="2023.12.0", force=True)
+        
+        assert result["success"] is True
+        mock_run_mise_command.assert_called_once()
+        # Check that version and force were passed
+        call_args = mock_run_mise_command.call_args[0]
+        assert "2023.12.0" in call_args[1]
+        assert "--force" in call_args[1]
+    
+    @pytest.mark.asyncio
+    async def test_fmt_config(self, mock_run_mise_command):
+        """Test formatting config files."""
+        mock_run_mise_command.return_value = CommandResult(
+            success=True,
+            output=".mise.toml\n.mise.local.toml",
+            error="",
+            return_code=0
+        )
+        
+        result = await fmt_config()
+        
+        assert result["success"] is True
+        assert len(result["formatted_files"]) == 2
+        assert ".mise.toml" in result["formatted_files"]


### PR DESCRIPTION
Adds:
- Mise-tasks-MCP

And GitHub Action workflow files to build all the Python MCP Servers build artifacts as OCI Artifacts, push it alongside MCP Server Images by signing the artifact with Cosign.